### PR TITLE
Create the empty credentials file incases where there's no credentials

### DIFF
--- a/juliohm~cifs/cifs
+++ b/juliohm~cifs/cifs
@@ -80,6 +80,7 @@ domount() {
   mkdir -p ${MNTPATH} &> /dev/null
 
   rm -fr /tmp/temporary.$PODID.tmp
+  touch /tmp/temporary.$PODID.tmp
   if [[ "$USERNAME" != "" ]]; then
     echo "username=$USERNAME" >> /tmp/temporary.$PODID.tmp
   fi


### PR DESCRIPTION
I use guest access to my media mounts, which means `/tmp/temporary.$PODID.tmp` never actually gets created, and thus mount fails with:
```
error 2 (No such file or directory) opening credential file /tmp/temporary.<PODID>.tmp
```

(but is silenced because of the 2>/dev/null)
